### PR TITLE
Add metadata info

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -3,3 +3,4 @@ for D in bin include lib libexec share xtensa-lx106-elf; do
 done
 
 rm -f package.json
+rm -f .piopm

--- a/init.sh
+++ b/init.sh
@@ -26,3 +26,15 @@ cat <<__EOF__ >package.json
     "version": "${VERSION}"
 }
 __EOF__
+
+cat <<__EOF__ >.piopm
+{
+    "name": "toolchain-xtensa",
+    "type": "toolchain",
+    "spec": {
+        "name": "toolchain-xtensa",
+        "owner": "platformio"
+    },
+    "version": "${VERSION}"
+}
+__EOF__


### PR DESCRIPTION
Since platformio introduced "owner" requirements for dependencies, we need another magic file.

See v5.0.1 release notes for details.